### PR TITLE
Remove setting content-length for response

### DIFF
--- a/component/src/org/wso2/ballerina/connectors/oauth2/ClientConnector.bal
+++ b/component/src/org/wso2/ballerina/connectors/oauth2/ClientConnector.bal
@@ -162,7 +162,6 @@ function getAccessTokenFromRefreshToken (http:Request request, string accessToke
     accessTokenFromRefreshTokenReq = refreshTokenPath + "?refresh_token=" + refreshToken
                                      + "&grant_type=refresh_token&client_secret="
                                      + clientSecret + "&client_id=" + clientId;
-    refreshTokenRequest.setContentLength(0);
     refreshTokenResponse, e = refreshTokenHTTPEP.post(accessTokenFromRefreshTokenReq, refreshTokenRequest);
     accessTokenFromRefreshTokenJSONResponse = refreshTokenResponse.getJsonPayload();
     accessToken = accessTokenFromRefreshTokenJSONResponse.access_token.toString();


### PR DESCRIPTION
## Purpose
In latest ballerina-http-connector, `setContentLength` function is
removed and the logic is handled internally. Hence removing the usage of `setContentLength`

## Goals
Fix the *undefined function* error

## Approach
Removed the usage of `setContentLength`

## User stories
N/A

## Release note
N/A

## Documentation
The upcoming release of the oauth connector will support ballerina run-time 0.95.6 or above

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
 - Unit tests 
N/A
 - Integration tests
N/A

## Security checks
N/A

## Samples
N/A

## Related PRs
https://github.com/ballerinalang/ballerina/pull/4254/files#diff-a415b4f89a79d315960cbf6753fbccf7L1

## Migrations (if applicable)
N/A

## Test environment
ballerina 0.95.6
 
## Learning
N/A