### PR TITLE
Fixed the issue with refreshing access token by sending client credentials in the request body

### DIFF
--- a/oauth2/oauth2_connector.bal
+++ b/oauth2/oauth2_connector.bal
@@ -16,7 +16,6 @@
 
 package oauth2;
 
-import ballerina/io;
 import ballerina/net.http;
 import ballerina/mime;
 import ballerina/util;
@@ -250,13 +249,13 @@ returns (string) | http:HttpConnectorError {
         accessTokenFromRefreshTokenReq = accessTokenFromRefreshTokenReq + "?" + requestParams;
     }
     var refreshTokenResponse = refreshTokenClient.post(accessTokenFromRefreshTokenReq, refreshTokenRequest);
-    io:println(httpRefreshTokenResponse);
+
     match refreshTokenResponse {
         http:Response httpResponse => httpRefreshTokenResponse = httpResponse;
         http:HttpConnectorError err => return err;
     }
     json accessTokenFromRefreshTokenJSONResponse =? httpRefreshTokenResponse.getJsonPayload();
-    io:println(accessTokenFromRefreshTokenJSONResponse);
+
 
     if (httpRefreshTokenResponse.statusCode == 200) {
         string accessToken = accessTokenFromRefreshTokenJSONResponse.access_token.toString();

--- a/oauth2/oauth2_endpoint.bal
+++ b/oauth2/oauth2_endpoint.bal
@@ -28,6 +28,7 @@ public struct OAuth2Configuration {
     string refreshTokenEP;
     string refreshTokenPath;
     boolean useUriParams = false;
+    boolean sendRefreshParamsInBody = false;
     http:ClientEndpointConfiguration clientConfig;
 }
 
@@ -39,13 +40,14 @@ public struct OAuth2Endpoint {
 
 public function <OAuth2Endpoint oAuth2EP> init (OAuth2Configuration oAuth2Configuration) {
     oAuth2EP.oAuth2Connector = { accessToken:oAuth2Configuration.accessToken,
-                       refreshToken:oAuth2Configuration.refreshToken,
-                       clientId:oAuth2Configuration.clientId,
-                       clientSecret:oAuth2Configuration.clientSecret,
-                       refreshTokenEP:oAuth2Configuration.refreshTokenEP,
-                       refreshTokenPath:oAuth2Configuration.refreshTokenPath,
-                       useUriParams:oAuth2Configuration.useUriParams,
-                       httpClient:http:createHttpClient(oAuth2Configuration.baseUrl, oAuth2Configuration.clientConfig)};
+                                   refreshToken:oAuth2Configuration.refreshToken,
+                                   clientId:oAuth2Configuration.clientId,
+                                   clientSecret:oAuth2Configuration.clientSecret,
+                                   refreshTokenEP:oAuth2Configuration.refreshTokenEP,
+                                   refreshTokenPath:oAuth2Configuration.refreshTokenPath,
+                                   useUriParams:oAuth2Configuration.useUriParams,
+                                   sendRefreshParamsInBody:oAuth2Configuration.sendRefreshParamsInBody,
+                                   httpClient:http:createHttpClient(oAuth2Configuration.baseUrl, oAuth2Configuration.clientConfig)};
 }
 
 public function <OAuth2Endpoint oAuth2EP> register(typedesc serviceType) {


### PR DESCRIPTION
Refreshing the access token by sending client credentials as request body didn't work and this fixes that issue. 
There was a issue regarding the useUriParams. (if useUriParams is false it uses URI parameters which is misleading.) Fixed that.